### PR TITLE
(GH-1162) Expand credentials filepath relative to Boltdir

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,9 +13,6 @@ AllCops:
 Style/IfUnlessModifier:
   Enabled: false
 
-Style/AccessModifierDeclarations:
-  Enabled: false
-
 Style/StringLiterals:
   Enabled: false
 
@@ -31,16 +28,7 @@ Style/NumericLiterals:
 Style/NumericPredicate:
   Enabled: false
 
-Style/StderrPuts:
-  Enabled: false
-
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-
 Layout/IndentHeredoc:
-  Enabled: false
-
-Layout/ClosingHeredocIndentation:
   Enabled: false
 
 Style/GuardClause:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Release 0.2.0
+
+### Bug fixes
+
+* **Expand `credentials` path relative to Boltdir** ([#1162](https://github.com/puppetlabs/bolt/issues/1162))
+
+  The `credentials` option will now be expanded relative to the active Boltdir the user is running bolt with, instead of the current working directory they ran Bolt from. This is part of standardizing all configurable paths in Bolt to be relative to the Boltdir.
+
 ## Release 0.1.0
 
 This is the initial release.

--- a/README.md
+++ b/README.md
@@ -31,15 +31,18 @@ Accessing EC2 instances requires a region and valid credentials to be specified.
 
 **Region**
 
--   `region: <region>` in the inventory file
+In order of precedence:
+
+-   `region: <region>` in the inventory or config file
 -   `ENV['AWS_REGION']`
--   `credentials: <filepath>` in the config file
 -   `~/.aws/credentials`
 
 **Credentials**
 
+In order of precedence:
+
+-   `credentials: <filepath>` in the inventory or config file
 -   `ENV['AWS_ACCESS_KEY_ID']` and `ENV['AWS_SECRET_ACCESS_KEY']`
--   `credentials: <filepath>` in the config file
 -   `~/.aws/credentials`
 
 If the region or credentials are located in a shared credentials file, a `profile` can be specified in the inventory file to choose which set of credentials to use. For example, if the inventory file were set to `profile: user1`, the second set of credentials would be used:
@@ -56,7 +59,7 @@ aws_secret_access_key=...
 region=...
 ```
 
-AWS credential files stored in a non-standard location (`~/.aws/credentials`) can be specified in the Bolt config file:
+AWS credential files stored in a non-standard location (`~/.aws/credentials`) can be configured in Bolt:
 
 ```
 plugins:
@@ -65,6 +68,7 @@ plugins:
 ```
 
 ### Examples
+
 `inventory.yaml`
 ```yaml
 groups:

--- a/metadata.json
+++ b/metadata.json
@@ -1,10 +1,11 @@
 {
   "name": "puppetlabs-aws_inventory",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Puppet, Inc.",
   "summary": "A task to generate Bolt inventory from AWS EC2 instances",
   "license": "Apache-2.0",
   "source": "git@github.com/puppetlabs/puppetlabs-aws_inventory",
+  "project_page": "https://github.com/puppetlabs/puppetlabs-aws_inventory",
   "dependencies": [
 
   ],

--- a/spec/tasks/resolve_reference_spec.rb
+++ b/spec/tasks/resolve_reference_spec.rb
@@ -73,8 +73,8 @@ describe AwsInventory do
 
   describe "#config_client" do
     it 'raises a validation error when credentials file path does not exist' do
-      config_data = { credentials: '~/foo/credentials' }
-      expect { subject.config_client(opts.merge(config_data)) }.to raise_error(%r{foo/credentials})
+      config_data = { credentials: 'credentials', _boltdir: 'who/are/you' }
+      expect { subject.config_client(opts.merge(config_data)) }.to raise_error(%r{who/are/you/credentials})
     end
   end
 

--- a/tasks/resolve_reference.rb
+++ b/tasks/resolve_reference.rb
@@ -20,11 +20,11 @@ class AwsInventory < TaskHelper
       options[:profile] = opts[:profile]
     end
     if opts[:credentials]
-      creds = File.expand_path(opts[:credentials])
+      creds = File.expand_path(opts[:credentials], opts[:_boltdir])
       if File.exist?(creds)
         options[:credentials] = Aws::SharedCredentials.new(path: creds)
       else
-        msg = "Cannot load credentials file #{opts[:credentials]}"
+        msg = "Cannot load credentials file #{creds}"
         raise TaskHelper::Error.new(msg, 'bolt-plugin/validation-error')
       end
     end


### PR DESCRIPTION
As part of standardizing configurable paths to be relative to the
Boltdir (if they're not absolute), the `credentials` config is now expanded
relative to the `_boltdir` option that's passed in rather than the
current working directory. This is part of the work for
puppetlabs/bolt#1162