### PR TITLE
(GH-1325) Use the Bolt plugin helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
 
 before_install:
 - git clone https://github.com/puppetlabs/puppetlabs-ruby_task_helper ../ruby_task_helper
+- git clone https://github.com/puppetlabs/puppetlabs-ruby_plugin_helper ../ruby_plugin_helper
 script:
 - bundle exec rake spec
 - bundle exec rubocop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Release 0.3.0
+
+## New features
+
+* **Added `target_mapping` parameter in `resolve_reference` task** ([#1407](https://github.com/puppetlabs/bolt/issues/1407))
+
+  The `resolve_reference` task has a new `target_mapping` parameter that accepts a hash of target attributes and the resource values to populate them with.
+
 ## Release 0.2.0
 
 ### Bug fixes

--- a/tasks/resolve_reference.json
+++ b/tasks/resolve_reference.json
@@ -1,6 +1,8 @@
 {
   "description": "Generate targets from AWS EC2 instances",
-  "files": ["ruby_task_helper/files/task_helper.rb"],
+  "files": ["ruby_task_helper/files/task_helper.rb",
+    "ruby_plugin_helper/lib/plugin_helper.rb"
+  ],
   "input_method": "stdin",
   "parameters": {
     "profile": {
@@ -15,14 +17,8 @@
     "credentials": {
       "type": "Optional[String]"
     },
-    "uri": {
-      "type": "Optional[String[1]]"
-    },
-    "name": {
-      "type": "Optional[String[1]]"
-    },
-    "config": {
-      "type": "Optional[Hash]"
+    "target_mapping": {
+      "type": "Hash"
     }
   }
 }

--- a/tasks/resolve_reference.rb
+++ b/tasks/resolve_reference.rb
@@ -2,10 +2,13 @@
 # frozen_string_literal: true
 
 require_relative '../../ruby_task_helper/files/task_helper.rb'
+require_relative '../../ruby_plugin_helper/lib/plugin_helper.rb'
 require 'json'
 require 'aws-sdk-ec2'
 
 class AwsInventory < TaskHelper
+  include RubyPluginHelper
+
   attr_accessor :client
 
   def config_client(opts)
@@ -33,76 +36,33 @@ class AwsInventory < TaskHelper
   end
 
   def resolve_reference(opts)
+    template = opts.delete(:target_mapping) || {}
+    unless template.key?(:uri) || template.key?(:name)
+      msg = "You must provide a 'name' or 'uri' in 'target_mapping' for the AWS plugin"
+      raise TaskHelper::Error.new(msg, 'bolt-plugin/validation-error')
+    end
+
     client = config_client(opts)
     resource = Aws::EC2::Resource.new(client: client)
 
     # Retrieve a list of EC2 instances and create a list of targets
     # Note: It doesn't seem possible to filter stubbed responses...
-    resource.instances(filters: opts[:filters]).map do |instance|
-      next unless instance.state.name == 'running'
-      target = {}
+    targets = resource.instances(filters: opts[:filters]).select { |i| i.state.name == 'running' }
 
-      if opts.key?(:uri)
-        uri = lookup(instance, opts[:uri])
-        target['uri'] = uri if uri
-      end
-      if opts.key?(:name)
-        real_name = lookup(instance, opts[:name])
-        target['name'] = real_name if real_name
-      end
-      if opts.key?(:config)
-        target['config'] = resolve_config(instance, opts[:config])
-      end
-
-      target if target['uri'] || target['name']
-    end.compact
-  end
-
-  # Look for an instance attribute specified in the inventory file
-  def lookup(instance, attribute)
-    instance.data.respond_to?(attribute) ? instance.data[attribute] : nil
-  end
-
-  # Walk the "template" config mapping provided in the plugin config and
-  # replace all values with the corresponding value from the resource
-  # parameters.
-  def resolve_config(name, config_template)
-    walk_vals(config_template) do |value|
-      if value.is_a?(String)
-        lookup(name, value)
-      else
-        value
+    attributes = required_data(template)
+    target_data = targets.map do |target|
+      attributes.each_with_object({}) do |attr, acc|
+        attr = attr.first
+        acc[attr] = target.respond_to?(attr) ? target.send(attr) : nil
       end
     end
+
+    target_data.map { |data| apply_mapping(template, data) }
   end
 
-  # Accepts a Data object and returns a copy with all hash and array values
-  # Arrays and hashes including the initial object are modified before
-  # their descendants are.
-  def walk_vals(data, skip_top = false, &block)
-    data = yield(data) unless skip_top
-    if data.is_a? Hash
-      map_vals(data) { |v| walk_vals(v, &block) }
-    elsif data.is_a? Array
-      data.map { |v| walk_vals(v, &block) }
-    else
-      data
-    end
-  end
-
-  def map_vals(hash)
-    hash.each_with_object({}) do |(k, v), acc|
-      acc[k] = yield(v)
-    end
-  end
-
-  def task(opts)
+  def task(opts = {})
     targets = resolve_reference(opts)
-    return { value: targets }
-  rescue TaskHelper::Error => e
-    # ruby_task_helper doesn't print errors under the _error key, so we have to
-    # handle that ourselves
-    return { _error: e.to_h }
+    { value: targets }
   end
 end
 


### PR DESCRIPTION
We've added a new Bolt plugin helper which abstracts common operations
from Bolt plugins, such as determining what values need to be looked up
by the plugin and then creating inventory data from the dynamic values.
This modifies the existing AWS inventory plugin to use the new plugin
helper by removing functions that are no longer needed and using those
from the helper instead.