### PR TITLE
(GH-8) Allow referencing tags in target_mapping

### DIFF
--- a/spec/tasks/resolve_reference_spec.rb
+++ b/spec/tasks/resolve_reference_spec.rb
@@ -13,11 +13,13 @@ describe AwsInventory do
       { instance_id: name1,
         public_ip_address: ip1,
         public_dns_name: name1,
-        state: { name: 'running' } },
+        state: { name: 'running' },
+        tags: [{ key: "Name", value: name1 }] },
       { instance_id: name2,
         public_ip_address: ip2,
         public_dns_name: name2,
-        state: { name: 'running' } }
+        state: { name: 'running' },
+        tags: [{ key: "Name", value: name2 }] }
     ]
   }
 
@@ -75,6 +77,14 @@ describe AwsInventory do
         config2 = { ssh: { host: ip2 } }
         expect(targets).to contain_exactly({ name: name1, uri: ip1, config: config1 },
                                            name: name2, uri: ip2, config: config2)
+      end
+
+      it 'allows tags to be referenced in target_mapping' do
+        opts[:target_mapping][:uri] = 'tags.Name'
+        targets = subject.resolve_reference(opts)
+
+        expect(targets).to contain_exactly({ name: name1, uri: name1 },
+                                           name: name2, uri: name2)
       end
 
       it 'raises an error if name or uri are not templated' do

--- a/tasks/resolve_reference.rb
+++ b/tasks/resolve_reference.rb
@@ -57,6 +57,18 @@ class AwsInventory < TaskHelper
       end
     end
 
+    # "tags" is a special case where we want to transform the array-of-maps
+    # structure returned from the API into a single key/value map so that
+    # tags can be referenced in a template
+    target_data.each do |target|
+      next unless target['tags']
+
+      tag_map = target['tags'].each_with_object({}) do |tag, tags|
+        tags[tag['key']] = tag['value']
+      end
+      target['tags'] = tag_map
+    end
+
     target_data.map { |data| apply_mapping(template, data) }
   end
 


### PR DESCRIPTION
Previously, the `tags` attribute couldn't be effectively used in
target_mapping because it contains an array of maps with "key" and
"value" fields. That makes it impossible to find the value of a specific
desired tag.

We now convert the `tags` attribute into a standard key/value map so
that tags can be looked up using `tags.Name` syntax.