### PR TITLE
(bug) Add missing dependencies to metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,18 @@
+## Release 0.5.1
+
+### Bug fixes
+
+* **Add missing dependencies to module metadata**
+  ([#10](https://github.com/puppetlabs/puppetlabs-aws_inventory/pull/11))
+
+  The module metadata now includes `ruby_plugin_helper` and `ruby_task_helper`
+  as dependencies.
+
 ## Release 0.5.0
 
 ### Bug fixes
 
-* **Reference tags in target_mapping** ([#9](https://github.com/puppetlabs/puppetlabs-aws_inventory/pulls/9))
+* **Reference tags in target_mapping** ([#9](https://github.com/puppetlabs/puppetlabs-aws_inventory/pull/9))
 
   Previously, the tags attribute couldn't be effectively used in
   target_mapping because it contains an array of maps with "key" and
@@ -13,7 +23,7 @@
 
 ### New features
 
-* **Set `resolve_reference` task to private** ([#6](https://github.com/puppetlabs/puppetlabs-aws_inventory/pulls/6))
+* **Set `resolve_reference` task to private** ([#6](https://github.com/puppetlabs/puppetlabs-aws_inventory/pull/6))
 
     The `resolve_reference` task has been set to `private` so it no longer appears in UI lists.
     

--- a/metadata.json
+++ b/metadata.json
@@ -1,13 +1,20 @@
 {
   "name": "puppetlabs-aws_inventory",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": "Puppet, Inc.",
   "summary": "A task to generate Bolt inventory from AWS EC2 instances",
   "license": "Apache-2.0",
   "source": "git@github.com/puppetlabs/puppetlabs-aws_inventory",
   "project_page": "https://github.com/puppetlabs/puppetlabs-aws_inventory",
   "dependencies": [
-
+    {
+      "name":"puppetlabs-ruby_plugin_helper",
+      "version_requirement":">= 0.1.0 < 1.0.0"
+    },
+    {
+      "name":"puppetlabs-ruby_task_helper",
+      "version_requirement":">= 0.4.0 < 1.0.0"
+    }
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
This adds `ruby_task_helper` and `ruby_plugin_helper` as dependencies in
the module metadata.