### PR TITLE
Add aws_access_key_id and aws_secret_access_key parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ The AWS Inventory plugin supports looking up running AWS EC2 instances. It suppo
 
 -   `profile`: The [named profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) to use when loading from AWS `config` and `credentials` files. (optional, defaults to `default`)
 -   `region`: The region to look up EC2 instances from.
+-   `credentials`: The path to an AWS credentials file to load. (optional, defaults to `~/.aws/credentials`)
+-   `aws_access_key_id`: The AWS access key id to use. (optional)
+-   `aws_secret_access_key`: The AWS secret access key to use. (optional)
 -   `filters`: The [filter request parameters](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html) used to filter the EC2 instances by. Filters are name-values pairs, where the name is a request parameter and the values are an array of values to filter by. (optional)
 -   `target_mapping`: A hash of target attributes to populate with resource values. The following attributes are available.
     - `config`: A bolt config map where the value for each config setting is an [EC2 instance attribute](https://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Instance.html).
@@ -43,6 +46,7 @@ In order of precedence:
 In order of precedence:
 
 -   `credentials: <filepath>` in the inventory or config file
+-   `aws_access_key_id` and `aws_secret_access_key` in the inventory or config file
 -   `ENV['AWS_ACCESS_KEY_ID']` and `ENV['AWS_SECRET_ACCESS_KEY']`
 -   `~/.aws/credentials`
 

--- a/spec/tasks/resolve_reference_spec.rb
+++ b/spec/tasks/resolve_reference_spec.rb
@@ -94,11 +94,21 @@ describe AwsInventory do
     end
   end
 
-  describe "#config_client" do
+  describe "#client_config" do
     it 'raises a validation error when credentials file path does not exist' do
       config_data = { credentials: 'credentials', _boltdir: 'who/are/you' }
-      expect { subject.config_client(opts.merge(config_data)) }
+      expect { subject.client_config(opts.merge(config_data)) }
         .to raise_error(%r{who/are/you/credentials})
+    end
+
+    it 'sets access_key_id if specified' do
+      config = subject.client_config(opts.merge(aws_access_key_id: 'my_access_key_id'))
+      expect(config[:access_key_id]).to eq('my_access_key_id')
+    end
+
+    it 'sets secret_access_key if specified' do
+      config = subject.client_config(opts.merge(aws_secret_access_key: 'my_secret_access_key'))
+      expect(config[:secret_access_key]).to eq('my_secret_access_key')
     end
   end
 

--- a/tasks/resolve_reference.json
+++ b/tasks/resolve_reference.json
@@ -17,6 +17,13 @@
     "credentials": {
       "type": "Optional[String]"
     },
+    "aws_access_key_id": {
+      "type": "Optional[String]"
+    },
+    "aws_secret_access_key": {
+      "type": "Optional[String]",
+      "sensitive": true
+    },
     "target_mapping": {
       "type": "Hash"
     }


### PR DESCRIPTION
Previously, the only ways to provide credentials to the
resolve_reference task were to put the credentials in a file or in an
environment variable. Both of those require managing some aspect of the
environment external to the task. To avoid that requirement, the task
now also accepts these credentials directly as parameters. If both
a `credentials` file and one of the individual credential parameters are
supplied, the contents of the credentials file will take precedence.