### PR TITLE
Add AWS tag usage example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ groups:
           config:
             ssh:
               host: public_dns_name
+              user: tag.User
     config:
       ssh:
         user: ec2-user


### PR DESCRIPTION
Adds an exampe of configuring the SSH user based on the tag `User` when
using the AWS inventory plugin in a Bolt inventory.