### PR TITLE
Add credential_process parameter to use external credential processes

### DIFF
--- a/spec/tasks/resolve_reference_spec.rb
+++ b/spec/tasks/resolve_reference_spec.rb
@@ -101,6 +101,12 @@ describe AwsInventory do
         .to raise_error(%r{who/are/you/credentials})
     end
 
+    it 'fails when credentials process path does not exist' do
+      config_data = { credential_process: '/path/to/command' }
+      expect { subject.client_config(opts.merge(config_data)) }
+        .to raise_error(%r{Could not find process /path/to/command})
+    end
+
     it 'sets access_key_id if specified' do
       config = subject.client_config(opts.merge(aws_access_key_id: 'my_access_key_id'))
       expect(config[:access_key_id]).to eq('my_access_key_id')

--- a/tasks/resolve_reference.json
+++ b/tasks/resolve_reference.json
@@ -17,6 +17,9 @@
     "credentials": {
       "type": "Optional[String]"
     },
+    "credential_process": {
+      "type": "Optional[String]"
+    },
     "aws_access_key_id": {
       "type": "Optional[String]"
     },

--- a/tasks/resolve_reference.rb
+++ b/tasks/resolve_reference.rb
@@ -28,6 +28,8 @@ class AwsInventory < TaskHelper
         msg = "Cannot load credentials file #{creds}"
         raise TaskHelper::Error.new(msg, 'bolt-plugin/validation-error')
       end
+    elsif opts[:credential_process]
+      config[:credentials] = Aws::ProcessCredentials.new(opts[:credential_process])
     else
       if opts.key?(:aws_access_key_id)
         config[:access_key_id] = opts[:aws_access_key_id]


### PR DESCRIPTION
This parameter can hopefully be useful in more complex authentication situations such as SSO or MFA.  The example in the documentation reflects our motivating use case of an IAM user assuming a role with a policy that requires MFA authentication. 



